### PR TITLE
Update IOUtils.java

### DIFF
--- a/src/platform/src/main/java/org/geoserver/util/IOUtils.java
+++ b/src/platform/src/main/java/org/geoserver/util/IOUtils.java
@@ -190,7 +190,7 @@ public class IOUtils {
      * <p>Strategy is to leverage the system temp directory, then create a sub-directory.
      */
     public static File createTempDirectory(String prefix) throws IOException {
-        File dummyTemp = File.createTempFile("blah", null);
+        File dummyTemp = Files.createTempFile("blah", null).toFile();
         String sysTempDir = dummyTemp.getParentFile().getAbsolutePath();
         dummyTemp.delete();
 


### PR DESCRIPTION
There may has a temporary file information disclosure vulnerability by use File.createTempFile().

There are many cases of this kind of writing in GeoServer, and I have only submitted one modification here.

**Preamble**
The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file permissions are set.

The chain of calls was detected in this repository in a way that leaves this project vulnerable. IOUtils.createTempDirectory() -> file.createNewFile().

**Impact**
This vulnerability can have one of two impacts depending upon which vulnerability it is.

1.Temporary Directory Information Disclosure - Information in this directory is visable to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files. 2.Temporary Directory Hijacking Vulnerability - Same impact as 1. above, but also, ther local users can manipulate/add contents to this directory. If code is being executed out of this temporary directory, it can lead to local priviledge escalation.

**Other Examples**
[CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

**The Fix**
The fix has been to convert the logic above to use the following API that was introduced in Java 1.7. File tmpDir = Files.createTempFile(prefix, suffix).toFile(); The API both created the directory securely, ie with a random, non-conflicting name, with directory permissions that only allow the currently executing user to read or write the contents of this directory.